### PR TITLE
excludes non equal selectors from the labels

### DIFF
--- a/_util.libsonnet
+++ b/_util.libsonnet
@@ -1,9 +1,12 @@
 {
+  local hasSubStr(pat, s) = std.findSubstr(pat, s) != [],
+
   selectorsToLabels(selectorArray):: {
     [s[0]]: std.strReplace(s[1], '"', '')
     for s in [
       std.split(s, '=')
       for s in selectorArray
+      if !hasSubStr('!=', s) && !hasSubStr('!~', s) && !hasSubStr('=~', s)
     ]
   },
 


### PR DESCRIPTION
Prometheus supports several selector operators [1]:

- `=`: Select labels that are exactly equal to the provided string.
- `!=`: Select labels that are not equal to the provided string.
- `=~`: Select labels that regex-match the provided string.
- `!~`: Select labels that do not regex-match the provided string.

We want to include in the generated labels only those that are exactly
equal to the provided string and discard the rest.

[1]: https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors